### PR TITLE
feat: centralize decoding logic and add sampling options

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -4,30 +4,25 @@ repo_root = os.path.abspath(os.path.join(current_dir, ".."))
 sys.path.insert(0, repo_root)
 
 from models.layout_transformer import LayoutTransformer
-from tokenizer.tokenizer import BlueprintTokenizer, BOS_ID, SEP_ID, EOS_ID
+from tokenizer.tokenizer import BlueprintTokenizer
+from models.decoding import decode
 from dataset.render_svg import render_layout_svg
 
 CKPT = os.path.join(repo_root, "checkpoints", "model_latest.pth")
-
-def greedy_decode(model, prefix_ids, max_len=160):
-    model.eval()
-    seq = prefix_ids[:]
-    with torch.no_grad():
-        for _ in range(max_len):
-            x = torch.tensor([seq], dtype=torch.long)
-            logits = model(x)[:, -1, :]
-            nxt = int(logits.argmax(dim=-1))
-            seq.append(nxt)
-            if nxt == EOS_ID: break
-    if SEP_ID in seq:
-        i = seq.index(SEP_ID) + 1
-        return seq[i:]
-    return seq
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--params_json", type=str, required=True)
     ap.add_argument("--out_prefix", type=str, default="generated_blueprint")
+    ap.add_argument(
+        "--strategy",
+        type=str,
+        default="greedy",
+        choices=["greedy", "sample", "beam"],
+        help="Decoding strategy",
+    )
+    ap.add_argument("--temperature", type=float, default=1.0)
+    ap.add_argument("--beam_size", type=int, default=5)
     args = ap.parse_args()
 
     params = json.load(open(args.params_json, "r", encoding="utf-8"))
@@ -38,13 +33,19 @@ def main():
     model.load_state_dict(torch.load(CKPT, map_location="cpu"))
 
     prefix = tk.encode_params(params)
-    layout_tokens = greedy_decode(model, prefix, max_len=160)
+    layout_tokens = decode(
+        model,
+        prefix,
+        max_len=160,
+        strategy=args.strategy,
+        temperature=args.temperature,
+        beam_size=args.beam_size,
+    )
     layout_json = tk.decode_layout_tokens(layout_tokens)
 
     json_path = f"{args.out_prefix}.json"
     svg_path = f"{args.out_prefix}.svg"
     json.dump(layout_json, open(json_path, "w", encoding="utf-8"), indent=2)
-    from dataset.render_svg import render_layout_svg
     render_layout_svg(layout_json, svg_path)
     print(f"✅ Wrote {json_path} and {svg_path}")
 

--- a/models/decoding.py
+++ b/models/decoding.py
@@ -1,0 +1,91 @@
+import torch
+from tokenizer.tokenizer import SEP_ID, EOS_ID
+
+
+def _trim_sequence(seq):
+    """Return portion after SEP_ID if present."""
+    if SEP_ID in seq:
+        i = seq.index(SEP_ID) + 1
+        return seq[i:]
+    return seq
+
+
+def greedy_decode(model, prefix_ids, max_len: int = 160):
+    """Generate tokens using greedy argmax decoding."""
+    model.eval()
+    seq = list(prefix_ids)
+    with torch.no_grad():
+        for _ in range(max_len):
+            x = torch.tensor([seq], dtype=torch.long)
+            logits = model(x)[:, -1, :]
+            nxt = int(logits.argmax(dim=-1))
+            seq.append(nxt)
+            if nxt == EOS_ID:
+                break
+    return _trim_sequence(seq)
+
+
+def sample_decode(
+    model,
+    prefix_ids,
+    max_len: int = 160,
+    temperature: float = 1.0,
+):
+    """Generate tokens using temperature sampling."""
+    model.eval()
+    seq = list(prefix_ids)
+    with torch.no_grad():
+        for _ in range(max_len):
+            x = torch.tensor([seq], dtype=torch.long)
+            logits = model(x)[:, -1, :] / temperature
+            probs = torch.softmax(logits, dim=-1)
+            nxt = int(torch.multinomial(probs, num_samples=1))
+            seq.append(nxt)
+            if nxt == EOS_ID:
+                break
+    return _trim_sequence(seq)
+
+
+def beam_search_decode(
+    model,
+    prefix_ids,
+    max_len: int = 160,
+    beam_size: int = 5,
+):
+    """Generate tokens using beam search."""
+    model.eval()
+    sequences = [(list(prefix_ids), 0.0)]  # (seq, score)
+    with torch.no_grad():
+        for _ in range(max_len):
+            all_candidates = []
+            for seq, score in sequences:
+                x = torch.tensor([seq], dtype=torch.long)
+                logits = model(x)[:, -1, :]
+                log_probs = torch.log_softmax(logits, dim=-1)
+                topk_log_probs, topk_ids = torch.topk(log_probs, beam_size)
+                for log_prob, idx in zip(topk_log_probs[0], topk_ids[0]):
+                    candidate = (seq + [int(idx)], score + float(log_prob))
+                    all_candidates.append(candidate)
+            sequences = sorted(all_candidates, key=lambda t: t[1], reverse=True)[:beam_size]
+            if any(seq[-1] == EOS_ID for seq, _ in sequences):
+                break
+    best_seq = sequences[0][0]
+    return _trim_sequence(best_seq)
+
+
+def decode(
+    model,
+    prefix_ids,
+    max_len: int = 160,
+    strategy: str = "greedy",
+    temperature: float = 1.0,
+    beam_size: int = 5,
+):
+    """Unified decoding interface."""
+    if strategy == "greedy":
+        return greedy_decode(model, prefix_ids, max_len)
+    if strategy == "sample":
+        return sample_decode(model, prefix_ids, max_len, temperature)
+    if strategy == "beam":
+        return beam_search_decode(model, prefix_ids, max_len, beam_size)
+    raise ValueError(f"Unknown decoding strategy: {strategy}")


### PR DESCRIPTION
## Summary
- add `models/decoding.py` with greedy, sampling, and beam-search routines
- use shared decoder in `Generate/generate_blueprint.py` and expose strategy CLI
- update API to import shared decoder and allow strategy, temperature, and beam size

## Testing
- `python -m py_compile models/decoding.py && echo OK_models`
- `python -m py_compile Generate/generate_blueprint.py && echo OK_gen2`
- `python -m py_compile api/app.py && echo OK_api`


