### PR TITLE
feat: add device selection

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -14,6 +14,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--params_json", type=str, required=True)
     ap.add_argument("--out_prefix", type=str, default="generated_blueprint")
+    ap.add_argument("--device", type=str, default="cpu", help="Device to run the model on")
     ap.add_argument(
         "--strategy",
         type=str,
@@ -30,7 +31,8 @@ def main():
     model = LayoutTransformer(tk.get_vocab_size())
     if not os.path.exists(CKPT):
         raise FileNotFoundError("Checkpoint not found. Train first (checkpoints/model_latest.pth).")
-    model.load_state_dict(torch.load(CKPT, map_location="cpu"))
+    model.load_state_dict(torch.load(CKPT, map_location=args.device))
+    model.to(args.device)
 
     prefix = tk.encode_params(params)
     layout_tokens = decode(

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ python scripts/build_jsonl.py
 # 2) Train
 python training/train.py --epochs 10 --batch 16
 
-# 3) Generate locally
-python Generate/generate_blueprint.py --params_json sample_params.json --out_prefix my_blueprint
+# 3) Generate locally (set device to "cpu" or "cuda")
+python Generate/generate_blueprint.py --params_json sample_params.json --out_prefix my_blueprint --device cuda
 
-# 4) Run API
-uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
+# 4) Run API (optional DEVICE env var controls model device)
+DEVICE=cuda uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
 # POST to /generate with params JSON; response contains layout JSON and data-URL SVG
 ```

--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,7 @@ from models.decoding import decode
 from dataset.render_svg import render_layout_svg
 
 CHECKPOINT = os.path.join(REPO_ROOT, "checkpoints", "model_latest.pth")
+DEVICE = os.environ.get("DEVICE", "cpu")
 
 class Bathrooms(BaseModel):
     full: int = 2
@@ -73,7 +74,8 @@ def _get_model():
             if not os.path.exists(CHECKPOINT):
                 raise FileNotFoundError("Model checkpoint not found. Train first.")
             _model = LayoutTransformer(_tokenizer.get_vocab_size())
-            _model.load_state_dict(torch.load(CHECKPOINT, map_location="cpu"))
+            _model.load_state_dict(torch.load(CHECKPOINT, map_location=DEVICE))
+            _model.to(DEVICE)
             _model.eval()
         return _model
 

--- a/models/decoding.py
+++ b/models/decoding.py
@@ -14,9 +14,10 @@ def greedy_decode(model, prefix_ids, max_len: int = 160):
     """Generate tokens using greedy argmax decoding."""
     model.eval()
     seq = list(prefix_ids)
+    device = next(model.parameters()).device
     with torch.no_grad():
         for _ in range(max_len):
-            x = torch.tensor([seq], dtype=torch.long)
+            x = torch.tensor([seq], dtype=torch.long, device=device)
             logits = model(x)[:, -1, :]
             nxt = int(logits.argmax(dim=-1))
             seq.append(nxt)
@@ -34,9 +35,10 @@ def sample_decode(
     """Generate tokens using temperature sampling."""
     model.eval()
     seq = list(prefix_ids)
+    device = next(model.parameters()).device
     with torch.no_grad():
         for _ in range(max_len):
-            x = torch.tensor([seq], dtype=torch.long)
+            x = torch.tensor([seq], dtype=torch.long, device=device)
             logits = model(x)[:, -1, :] / temperature
             probs = torch.softmax(logits, dim=-1)
             nxt = int(torch.multinomial(probs, num_samples=1))
@@ -55,11 +57,12 @@ def beam_search_decode(
     """Generate tokens using beam search."""
     model.eval()
     sequences = [(list(prefix_ids), 0.0)]  # (seq, score)
+    device = next(model.parameters()).device
     with torch.no_grad():
         for _ in range(max_len):
             all_candidates = []
             for seq, score in sequences:
-                x = torch.tensor([seq], dtype=torch.long)
+                x = torch.tensor([seq], dtype=torch.long, device=device)
                 logits = model(x)[:, -1, :]
                 log_probs = torch.log_softmax(logits, dim=-1)
                 topk_log_probs, topk_ids = torch.topk(log_probs, beam_size)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from pathlib import Path
+import importlib
+import torch
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from tokenizer.tokenizer import EOS_ID
+
+
+class DummyModel(torch.nn.Module):
+    """Minimal model that always predicts EOS."""
+    def __init__(self, vocab_size: int = 10):
+        super().__init__()
+        # single parameter so model has a device
+        self.param = torch.nn.Parameter(torch.zeros(1))
+        self.vocab_size = vocab_size
+
+    def forward(self, x):
+        batch, seq_len = x.shape
+        logits = torch.zeros(batch, seq_len, self.vocab_size, device=x.device)
+        logits[:, :, EOS_ID] = 10.0  # force EOS
+        return logits
+
+
+def dummy_render(layout_json, svg_path):
+    Path(svg_path).write_text("<svg></svg>")
+
+
+@pytest.fixture()
+def dummy_checkpoint(tmp_path):
+    ckpt_dir = Path("checkpoints")
+    ckpt_dir.mkdir(exist_ok=True)
+    ckpt_path = ckpt_dir / "model_latest.pth"
+    torch.save(DummyModel().state_dict(), ckpt_path)
+    yield ckpt_path
+    ckpt_path.unlink(missing_ok=True)
+    ckpt_dir.rmdir()
+
+
+def test_generate_blueprint_device_flag(dummy_checkpoint, monkeypatch, tmp_path):
+    import Generate.generate_blueprint as gb
+    # patch model and rendering
+    monkeypatch.setattr(gb, "LayoutTransformer", DummyModel)
+    monkeypatch.setattr(gb, "render_layout_svg", dummy_render)
+
+    out_prefix = tmp_path / "output"
+    argv = [
+        "generate_blueprint.py",
+        "--params_json",
+        str(Path("sample_params.json")),
+        "--out_prefix",
+        str(out_prefix),
+        "--device",
+        "cpu",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    gb.main()
+    assert (Path(str(out_prefix) + ".json").exists())
+    assert (Path(str(out_prefix) + ".svg").exists())
+
+
+def test_api_respects_device_env(dummy_checkpoint, monkeypatch):
+    os.environ["DEVICE"] = "cpu"
+    app_module = importlib.import_module("api.app")
+    importlib.reload(app_module)
+    monkeypatch.setattr(app_module, "LayoutTransformer", DummyModel)
+    monkeypatch.setattr(app_module, "render_layout_svg", dummy_render)
+    model = app_module._get_model()
+    assert next(model.parameters()).device.type == "cpu"


### PR DESCRIPTION
## Summary
- add `--device` flag to `generate_blueprint.py`
- allow API to select device via `DEVICE` env var
- ensure decoding tensors are created on the model's device
- document device usage in README
- add smoke tests for CLI and API device handling

## Testing
- `python -m py_compile Generate/generate_blueprint.py api/app.py models/decoding.py tests/test_device.py`
- `pytest -q`


