### PR TITLE
Add reproducible dataset shuffling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 
 # 1) Build synthetic data + pairs
 python dataset/generate_dataset.py
-python scripts/build_jsonl.py
+python scripts/build_jsonl.py --seed 42  # use --seed for reproducible shuffling
 
 # 2) Train
 python training/train.py --epochs 10 --batch 16
@@ -26,3 +26,5 @@ python Generate/generate_blueprint.py --params_json sample_params.json --out_pre
 DEVICE=cuda uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
 # POST to /generate with params JSON; response contains layout JSON and data-URL SVG
 ```
+
+The `--seed` flag on `build_jsonl.py` ensures the shuffled train/val split is reproducible.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi>=0.110
 uvicorn>=0.29
 svgwrite>=1.4
 pydantic>=2.6
+numpy>=1.26

--- a/scripts/build_jsonl.py
+++ b/scripts/build_jsonl.py
@@ -1,29 +1,69 @@
-import os, json, random
+import os
+import json
+import random
+import argparse
 
-IN_DIR = "./dataset/datasets/synthetic"
-OUT_DIR = "./dataset"
-os.makedirs(OUT_DIR, exist_ok=True)
+try:
+    import numpy as np
+except Exception:  # NumPy not available
+    np = None
 
-pairs = []
-files = sorted([f for f in os.listdir(IN_DIR) if f.startswith("input_") and f.endswith(".json")])
-for f in files:
-    idx = f.split("_")[1].split(".")[0]
-    inp = json.load(open(os.path.join(IN_DIR, f), "r", encoding="utf-8"))
-    lp = os.path.join(IN_DIR, f"layout_{idx}.json")
-    if os.path.exists(lp):
-        layout = json.load(open(lp, "r", encoding="utf-8"))
-        # ensure all rooms contain coordinate fields
-        for room in layout.get("layout", {}).get("rooms", []):
-            room.setdefault("position", {"x": 0, "y": 0})
-        pairs.append({"params": inp, "layout": layout})
+if np is not None:
+    try:
+        import torch  # type: ignore
+    except Exception:  # PyTorch not available
+        torch = None
+else:
+    torch = None
 
-random.shuffle(pairs)
-cut = int(0.9 * len(pairs)) if pairs else 0
-train, val = pairs[:cut], pairs[cut:]
 
-with open(os.path.join(OUT_DIR, "train.jsonl"), "w", encoding="utf-8") as wf:
-    for r in train: wf.write(json.dumps(r) + "\n")
-with open(os.path.join(OUT_DIR, "val.jsonl"), "w", encoding="utf-8") as wf:
-    for r in val: wf.write(json.dumps(r) + "\n")
+def main(seed: int = 42) -> None:
+    random.seed(seed)
+    if np is not None:
+        np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
 
-print(f"✅ Wrote {len(train)} train and {len(val)} val rows to {OUT_DIR}")
+    in_dir = "./dataset/datasets/synthetic"
+    out_dir = "./dataset"
+    os.makedirs(out_dir, exist_ok=True)
+
+    pairs = []
+    files = sorted(
+        [f for f in os.listdir(in_dir) if f.startswith("input_") and f.endswith(".json")]
+    )
+    for f in files:
+        idx = f.split("_")[1].split(".")[0]
+        inp = json.load(open(os.path.join(in_dir, f), "r", encoding="utf-8"))
+        lp = os.path.join(in_dir, f"layout_{idx}.json")
+        if os.path.exists(lp):
+            layout = json.load(open(lp, "r", encoding="utf-8"))
+            # ensure all rooms contain coordinate fields
+            for room in layout.get("layout", {}).get("rooms", []):
+                room.setdefault("position", {"x": 0, "y": 0})
+            pairs.append({"params": inp, "layout": layout})
+
+    random.shuffle(pairs)
+    cut = int(0.9 * len(pairs)) if pairs else 0
+    train, val = pairs[:cut], pairs[cut:]
+
+    with open(os.path.join(out_dir, "train.jsonl"), "w", encoding="utf-8") as wf:
+        for r in train:
+            wf.write(json.dumps(r) + "\n")
+    with open(os.path.join(out_dir, "val.jsonl"), "w", encoding="utf-8") as wf:
+        for r in val:
+            wf.write(json.dumps(r) + "\n")
+
+    print(f"✅ Wrote {len(train)} train and {len(val)} val rows to {out_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build train/val JSONL datasets.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for shuffling and any libraries in use.",
+    )
+    args = parser.parse_args()
+    main(args.seed)


### PR DESCRIPTION
## Summary
- add `--seed` CLI flag to `build_jsonl.py` and seed Python, NumPy, and PyTorch RNGs
- document the reproducibility flag in the dataset generation instructions
- include NumPy dependency and guard PyTorch import to eliminate missing NumPy warnings

## Testing
- `python scripts/build_jsonl.py --seed 42`
- `pytest -q`


