### PR TITLE
feat: enhance dataset generation and ingestion

### DIFF
--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -1,54 +1,123 @@
-import os, json, sys
+import os
+import json
+import sys
+import random
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from dataset.render_svg import render_layout_svg
 
 OUT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'datasets/synthetic'))
-os.makedirs(OUT_DIR, exist_ok=True)
 
-def sample_parameters(i):
-    # simple random-ish params; replace with your sampler
+STYLES = ["Craftsman", "Modern", "Colonial", "Ranch", "Mediterranean"]
+SIZES = ["small", "medium", "large"]
+ROOM_TYPES = ["Bedroom", "Bathroom", "Kitchen", "Living Room", "Dining Room", "Office"]
+
+
+def sample_parameters(i, rng=random):
+    """Sample varied architectural parameters."""
+    size = rng.choice(SIZES)
+    square_feet = {"small": 1000, "medium": 2000, "large": 3000}[size]
     return {
-        "houseStyle": "Craftsman" if i % 2 == 0 else "Modern",
-        "bedrooms": 3 + (i % 3),
-        "bathrooms": {"full": 2 + (i % 2)},
-        "foundationType": "basement" if i % 2 else "slab",
-        "bonusRoom": bool(i % 2),
-        "attic": bool((i+1) % 2),
-        "fireplace": True,
-        "ownerSuiteLocation": "main floor",
-        "masterBathOption": "both",
-        "ceilingHeight": 9,
-        "garage": {"attached": True, "carCount": 2},
+        "houseStyle": rng.choice(STYLES),
+        "squareFeet": square_feet,
+        "bedrooms": rng.randint(2, 5),
+        "bathrooms": {"full": rng.randint(1, 3)},
+        "foundationType": rng.choice(["slab", "basement", "crawlspace"]),
+        "bonusRoom": rng.choice([True, False]),
+        "attic": rng.choice([True, False]),
+        "fireplace": rng.choice([True, False]),
+        "ownerSuiteLocation": rng.choice(["main floor", "second floor"]),
+        "ceilingHeight": rng.choice([8, 9, 10]),
+        "garage": {"attached": rng.choice([True, False]), "carCount": rng.randint(1, 3)},
     }
 
-def dummy_layout(i):
-    """Generate a simple layout with x/y coordinates on a grid.
 
-    The intent is to provide coordinate supervision for the model, so we
-    shift a base offset for each sample and place rooms relative to it.
-    """
-    base_x = (i * 3) % 20  # keep within 0-40ft bounds used by tokenizer
-    base_y = (i * 5) % 20
-    rooms = [
-        {"type": "Bedroom", "position": {"x": base_x, "y": base_y}, "size": {"width": 12, "length": 12}},
-        {"type": "Bathroom", "position": {"x": base_x + 12, "y": base_y}, "size": {"width": 8, "length": 8}},
-        {"type": "Kitchen", "position": {"x": base_x, "y": base_y + 12}, "size": {"width": 14, "length": 12}},
-        {"type": "Living Room", "position": {"x": base_x + 14, "y": base_y + 12}, "size": {"width": 16, "length": 14}},
-    ]
+def random_layout(i, rng=random):
+    """Generate a random layout with explicit x/y coordinates."""
+    base_x = rng.randint(0, 20)
+    base_y = rng.randint(0, 20)
+    rooms = []
+    for _ in range(rng.randint(3, 6)):
+        room_type = rng.choice(ROOM_TYPES)
+        x = base_x + rng.randint(0, 20)
+        y = base_y + rng.randint(0, 20)
+        width = rng.randint(8, 16)
+        length = rng.randint(8, 16)
+        rooms.append({
+            "type": room_type,
+            "position": {"x": x, "y": y},
+            "size": {"width": width, "length": length},
+        })
     return {"layout": {"rooms": rooms}}
 
-def main(n=50):
-    for i in range(n):
-        params = sample_parameters(i)
-        layout = dummy_layout(i)
-        ip = os.path.join(OUT_DIR, f"input_{i:05d}.json")
-        lp = os.path.join(OUT_DIR, f"layout_{i:05d}.json")
-        sp = os.path.join(OUT_DIR, f"layout_{i:05d}.svg")
-        with open(ip, "w", encoding="utf-8") as f: json.dump(params, f, indent=2)
-        with open(lp, "w", encoding="utf-8") as f: json.dump(layout, f, indent=2)
+
+def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0):
+    """Ingest external floor-plan JSON files and normalize to internal schema."""
+    idx = start_index
+    for fname in sorted(os.listdir(external_dir)):
+        if not fname.endswith('.json'):
+            continue
+        with open(os.path.join(external_dir, fname), 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        rooms = []
+        for room in data.get("rooms", []):
+            if "x" not in room or "y" not in room:
+                raise ValueError(f"Room missing coordinates in {fname}")
+            size = {"width": room.get("width", 10), "length": room.get("length", 10)}
+            rooms.append({
+                "type": room.get("type", "Room"),
+                "position": {"x": room["x"], "y": room["y"]},
+                "size": size,
+            })
+
+        layout = {"layout": {"rooms": rooms}}
+        params = data.get("params", {"houseStyle": "External", "squareFeet": data.get("squareFeet", 0)})
+
+        ip = os.path.join(out_dir, f"input_{idx:05d}.json")
+        lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
+        sp = os.path.join(out_dir, f"layout_{idx:05d}.svg")
+        with open(ip, "w", encoding="utf-8") as f:
+            json.dump(params, f, indent=2)
+        with open(lp, "w", encoding="utf-8") as f:
+            json.dump(layout, f, indent=2)
         render_layout_svg(layout, sp)
-    print(f"✅ Wrote {n} pairs to {OUT_DIR}")
+        idx += 1
+    return idx - start_index
+
+
+def main(n=50, out_dir=OUT_DIR, external_dir=None, seed=None):
+    os.makedirs(out_dir, exist_ok=True)
+    rng = random.Random(seed)
+    idx = 0
+    for _ in range(n):
+        params = sample_parameters(idx, rng)
+        layout = random_layout(idx, rng)
+        ip = os.path.join(out_dir, f"input_{idx:05d}.json")
+        lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
+        sp = os.path.join(out_dir, f"layout_{idx:05d}.svg")
+        with open(ip, "w", encoding="utf-8") as f:
+            json.dump(params, f, indent=2)
+        with open(lp, "w", encoding="utf-8") as f:
+            json.dump(layout, f, indent=2)
+        render_layout_svg(layout, sp)
+        idx += 1
+
+    if external_dir:
+        idx += ingest_external_dataset(external_dir, out_dir, start_index=idx)
+
+    print(f"✅ Wrote {idx} pairs to {out_dir}")
+
 
 if __name__ == "__main__":
-    main(100)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate synthetic floor-plan dataset")
+    parser.add_argument("--n", type=int, default=100, help="number of synthetic samples to generate")
+    parser.add_argument("--external_dir", type=str, default=None, help="path to external JSON floor-plan dataset")
+    parser.add_argument("--out_dir", type=str, default=OUT_DIR, help="output directory")
+    parser.add_argument("--seed", type=int, default=None, help="random seed for reproducibility")
+    args = parser.parse_args()
+
+    main(n=args.n, out_dir=args.out_dir, external_dir=args.external_dir, seed=args.seed)

--- a/tests/test_dataset_generation.py
+++ b/tests/test_dataset_generation.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+
+def dummy_render(layout, path):
+    Path(path).write_text("<svg></svg>")
+
+
+def test_generated_dataset_has_coordinates(tmp_path, monkeypatch):
+    from dataset import generate_dataset as gd
+
+    monkeypatch.setattr(gd, "render_layout_svg", dummy_render)
+    out_dir = tmp_path / "synthetic"
+
+    gd.main(n=5, out_dir=str(out_dir), seed=0)
+
+    coords = set()
+    for layout_file in out_dir.glob("layout_*.json"):
+        data = json.loads(layout_file.read_text())
+        for room in data["layout"]["rooms"]:
+            assert "x" in room["position"] and "y" in room["position"]
+            coords.add((room["position"]["x"], room["position"]["y"]))
+
+    # ensure coordinates vary across samples
+    assert len(coords) > 1
+
+
+def test_external_ingestion(tmp_path, monkeypatch):
+    from dataset import generate_dataset as gd
+
+    monkeypatch.setattr(gd, "render_layout_svg", dummy_render)
+
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    sample = {
+        "rooms": [{"type": "Bedroom", "x": 1, "y": 2, "width": 10, "length": 11}],
+        "params": {"houseStyle": "External", "squareFeet": 1200},
+    }
+    (external_dir / "plan.json").write_text(json.dumps(sample))
+
+    out_dir = tmp_path / "synthetic"
+    gd.main(n=0, external_dir=str(external_dir), out_dir=str(out_dir), seed=0)
+
+    layout_file = next(out_dir.glob("layout_*.json"))
+    data = json.loads(layout_file.read_text())
+    room = data["layout"]["rooms"][0]
+    assert room["position"] == {"x": 1, "y": 2}


### PR DESCRIPTION
## Summary
- expand synthetic generator to sample varied styles, sizes, and room layouts
- allow optional ingestion of external floor-plan JSON datasets normalized to internal schema
- verify explicit room coordinates and dataset diversity via new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4c7749220832c830e3120217a2462