### PR TITLE
Precompute tokens and add dataset augmentation

### DIFF
--- a/dataset/augmentation.py
+++ b/dataset/augmentation.py
@@ -1,0 +1,40 @@
+import copy
+from typing import Dict
+
+
+def mirror_layout(layout: Dict) -> Dict:
+    """Mirror layout horizontally across its bounding box."""
+    out = copy.deepcopy(layout)
+    rooms = out.get("layout", {}).get("rooms", [])
+    if not rooms:
+        return out
+    xs = [r["position"]["x"] for r in rooms]
+    min_x, max_x = min(xs), max(xs)
+    for r in rooms:
+        r["position"]["x"] = max_x - (r["position"]["x"] - min_x)
+    return out
+
+
+def rotate_layout(layout: Dict) -> Dict:
+    """Rotate layout 90 degrees around its bounding box."""
+    out = copy.deepcopy(layout)
+    rooms = out.get("layout", {}).get("rooms", [])
+    if not rooms:
+        return out
+    xs = [r["position"]["x"] for r in rooms]
+    ys = [r["position"]["y"] for r in rooms]
+    min_x, max_x = min(xs), max(xs)
+    min_y = min(ys)
+    width = max_x - min_x
+    for r in rooms:
+        x, y = r["position"]["x"], r["position"]["y"]
+        r["position"]["x"] = y - min_y + min_x
+        r["position"]["y"] = width - (x - min_x) + min_y
+        w, l = r["size"]["width"], r["size"]["length"]
+        r["size"]["width"], r["size"]["length"] = l, w
+    return out
+
+
+def augment_layout(layout: Dict) -> Dict:
+    """Return mirrored and rotated variants of the layout."""
+    return [mirror_layout(layout), rotate_layout(layout)]

--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -6,6 +6,7 @@ import random
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from dataset.render_svg import render_layout_svg
+from dataset.augmentation import mirror_layout, rotate_layout
 
 OUT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'datasets/synthetic'))
 
@@ -52,7 +53,7 @@ def random_layout(i, rng=random):
     return {"layout": {"rooms": rooms}}
 
 
-def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0):
+def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0, augment=False):
     """Ingest external floor-plan JSON files and normalize to internal schema."""
     idx = start_index
     for fname in sorted(os.listdir(external_dir)):
@@ -75,37 +76,42 @@ def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0):
         layout = {"layout": {"rooms": rooms}}
         params = data.get("params", {"houseStyle": "External", "squareFeet": data.get("squareFeet", 0)})
 
-        ip = os.path.join(out_dir, f"input_{idx:05d}.json")
-        lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
-        sp = os.path.join(out_dir, f"layout_{idx:05d}.svg")
-        with open(ip, "w", encoding="utf-8") as f:
-            json.dump(params, f, indent=2)
-        with open(lp, "w", encoding="utf-8") as f:
-            json.dump(layout, f, indent=2)
-        render_layout_svg(layout, sp)
+        _write_sample(params, layout, out_dir, idx)
         idx += 1
+        if augment:
+            for aug_layout in (mirror_layout(layout), rotate_layout(layout)):
+                _write_sample(params, aug_layout, out_dir, idx)
+                idx += 1
     return idx - start_index
 
 
-def main(n=50, out_dir=OUT_DIR, external_dir=None, seed=None):
+def _write_sample(params, layout, out_dir, idx):
+    ip = os.path.join(out_dir, f"input_{idx:05d}.json")
+    lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
+    sp = os.path.join(out_dir, f"layout_{idx:05d}.svg")
+    with open(ip, "w", encoding="utf-8") as f:
+        json.dump(params, f, indent=2)
+    with open(lp, "w", encoding="utf-8") as f:
+        json.dump(layout, f, indent=2)
+    render_layout_svg(layout, sp)
+
+
+def main(n=50, out_dir=OUT_DIR, external_dir=None, seed=None, augment=False):
     os.makedirs(out_dir, exist_ok=True)
     rng = random.Random(seed)
     idx = 0
     for _ in range(n):
         params = sample_parameters(idx, rng)
         layout = random_layout(idx, rng)
-        ip = os.path.join(out_dir, f"input_{idx:05d}.json")
-        lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
-        sp = os.path.join(out_dir, f"layout_{idx:05d}.svg")
-        with open(ip, "w", encoding="utf-8") as f:
-            json.dump(params, f, indent=2)
-        with open(lp, "w", encoding="utf-8") as f:
-            json.dump(layout, f, indent=2)
-        render_layout_svg(layout, sp)
+        _write_sample(params, layout, out_dir, idx)
         idx += 1
+        if augment:
+            for aug_layout in (mirror_layout(layout), rotate_layout(layout)):
+                _write_sample(params, aug_layout, out_dir, idx)
+                idx += 1
 
     if external_dir:
-        idx += ingest_external_dataset(external_dir, out_dir, start_index=idx)
+        idx += ingest_external_dataset(external_dir, out_dir, start_index=idx, augment=augment)
 
     print(f"✅ Wrote {idx} pairs to {out_dir}")
 
@@ -118,6 +124,7 @@ if __name__ == "__main__":
     parser.add_argument("--external_dir", type=str, default=None, help="path to external JSON floor-plan dataset")
     parser.add_argument("--out_dir", type=str, default=OUT_DIR, help="output directory")
     parser.add_argument("--seed", type=int, default=None, help="random seed for reproducibility")
+    parser.add_argument("--augment", action="store_true", help="apply simple mirroring/rotation augmentations")
     args = parser.parse_args()
 
-    main(n=args.n, out_dir=args.out_dir, external_dir=args.external_dir, seed=args.seed)
+    main(n=args.n, out_dir=args.out_dir, external_dir=args.external_dir, seed=args.seed, augment=args.augment)

--- a/scripts/build_jsonl.py
+++ b/scripts/build_jsonl.py
@@ -3,6 +3,8 @@ import json
 import random
 import argparse
 
+from tokenizer.tokenizer import BlueprintTokenizer
+
 try:
     import numpy as np
 except Exception:  # NumPy not available
@@ -29,6 +31,7 @@ def main(seed: int = 42) -> None:
     os.makedirs(out_dir, exist_ok=True)
 
     pairs = []
+    tk = BlueprintTokenizer()
     files = sorted(
         [f for f in os.listdir(in_dir) if f.startswith("input_") and f.endswith(".json")]
     )
@@ -41,7 +44,8 @@ def main(seed: int = 42) -> None:
             # ensure all rooms contain coordinate fields
             for room in layout.get("layout", {}).get("rooms", []):
                 room.setdefault("position", {"x": 0, "y": 0})
-            pairs.append({"params": inp, "layout": layout})
+            x_ids, y_ids = tk.build_training_pair(inp, layout)
+            pairs.append({"params": inp, "layout": layout, "x": x_ids, "y": y_ids})
 
     random.shuffle(pairs)
     cut = int(0.9 * len(pairs)) if pairs else 0

--- a/training/train.py
+++ b/training/train.py
@@ -24,6 +24,12 @@ class PairDataset(Dataset):
 
     def __getitem__(self, idx):
         row = self.rows[idx]
+        if "x" in row and "y" in row:
+            return (
+                torch.tensor(row["x"], dtype=torch.long),
+                torch.tensor(row["y"], dtype=torch.long),
+            )
+
         # ensure coordinate fields are present so position tokens can be learned
         for room in row.get("layout", {}).get("layout", {}).get("rooms", []):
             room.setdefault("position", {"x": 0, "y": 0})


### PR DESCRIPTION
## Summary
- Precompute training token pairs in `build_jsonl.py` using `BlueprintTokenizer` and support deterministic seeds
- Allow training to read pretokenized `x`/`y` sequences
- Add mirroring and rotation augmentation routines and `--augment` flag for dataset generation

## Testing
- `pytest -q`


