### PR TITLE
Add sampling and beam search decoding with room separation

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -8,6 +8,7 @@ from models.layout_transformer import LayoutTransformer
 from tokenizer.tokenizer import BlueprintTokenizer
 from models.decoding import decode
 from dataset.render_svg import render_layout_svg
+from evaluation.validators import enforce_min_separation
 from Generate.params import Params
 
 CKPT = os.path.join(repo_root, "checkpoints", "model_latest.pth")
@@ -52,6 +53,7 @@ def main():
         beam_size=args.beam_size,
     )
     layout_json = tk.decode_layout_tokens(layout_tokens)
+    layout_json = enforce_min_separation(layout_json)
 
     json_path = f"{args.out_prefix}.json"
     svg_path = f"{args.out_prefix}.svg"

--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,7 @@ from tokenizer.tokenizer import BlueprintTokenizer
 from models.layout_transformer import LayoutTransformer
 from models.decoding import decode
 from dataset.render_svg import render_layout_svg
+from evaluation.validators import enforce_min_separation
 from Generate.params import Params
 
 CHECKPOINT = os.path.join(REPO_ROOT, "checkpoints", "model_latest.pth")
@@ -82,6 +83,7 @@ def generate(
         beam_size=beam_size,
     )
     layout_json = _tokenizer.decode_layout_tokens(layout_tokens)
+    layout_json = enforce_min_separation(layout_json)
 
     out_dir = os.path.join(REPO_ROOT, "generated")
     os.makedirs(out_dir, exist_ok=True)

--- a/models/decoding.py
+++ b/models/decoding.py
@@ -32,7 +32,13 @@ def sample_decode(
     max_len: int = 160,
     temperature: float = 1.0,
 ):
-    """Generate tokens using temperature sampling."""
+    """Generate tokens using temperature sampling.
+
+    Args:
+        temperature: Sampling temperature. Must be > 0.
+    """
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
     model.eval()
     seq = list(prefix_ids)
     device = next(model.parameters()).device


### PR DESCRIPTION
## Summary
- Allow temperature sampling and beam search strategies during decoding
- Expose decoding options in CLI and API while enforcing minimum room spacing
- Post-process generated layouts to maintain a minimum separation between rooms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4d66e21ec832cba248623af9f9c15