### PR TITLE
Add async job queue with status polling and websockets

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+import time
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,7 +15,7 @@ def dummy_render(layout_json, svg_path):
         f.write("<svg></svg>")
 
 
-def test_generate_returns_paths_and_metadata(tmp_path):
+def test_generate_returns_job_and_result(tmp_path):
     client = TestClient(app)
     payload = {"params": {}}
     with patch("api.app._get_model", lambda: object()), \
@@ -26,15 +27,21 @@ def test_generate_returns_paths_and_metadata(tmp_path):
          patch("api.app.REPO_ROOT", str(tmp_path)), \
          patch("api.app.uuid.uuid4") as mock_uuid:
         mock_uuid.side_effect = [uuid.UUID(int=1), uuid.UUID(int=2)]
-        resp1 = client.post("/generate", json=payload)
-        resp2 = client.post("/generate", json=payload)
-    assert resp1.status_code == 200
-    assert resp2.status_code == 200
-    data1 = resp1.json()
-    data2 = resp2.json()
-    assert data1["svg_filename"] != data2["svg_filename"]
-    assert "saved_svg_path" in data1 and "saved_json_path" in data1
-    assert data1["metadata"]["processing_time"] >= 0
+        resp = client.post("/generate", json=payload)
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+        for _ in range(10):
+            status_resp = client.get(f"/status/{job_id}")
+            assert status_resp.status_code == 200
+            data = status_resp.json()
+            if data["status"] == "completed":
+                break
+            time.sleep(0.1)
+    assert data["status"] == "completed"
+    result = data["result"]
+    assert "saved_svg_path" in result and "saved_json_path" in result
+    assert result["svg_filename"] and result["json_filename"]
+    assert result["metadata"]["processing_time"] >= 0
 
 
 def test_validation_error_has_metadata():


### PR DESCRIPTION
## Summary
- process generation requests via background job queue
- return job IDs and add endpoints for status polling and websocket updates
- track and expose intermediate logs for each job

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a6197798e4832cbbf12fd1b14aa90c