### PR TITLE
Serve front-end via FastAPI

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from fastapi.exceptions import RequestValidationError
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from prometheus_client import (
     Counter,
@@ -15,6 +16,7 @@ from prometheus_client import (
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+WEB_DIR = os.path.join(REPO_ROOT, "interface", "web")
 sys.path.insert(0, REPO_ROOT)
 
 from tokenizer.tokenizer import BlueprintTokenizer
@@ -391,3 +393,6 @@ async def job_updates(websocket: WebSocket, job_id: str):
         logger.info("WebSocket disconnected for job %s", job_id)
     finally:
         await websocket.close()
+
+
+app.mount("/", StaticFiles(directory=WEB_DIR, html=True), name="web")

--- a/interface/web/app.js
+++ b/interface/web/app.js
@@ -1,0 +1,88 @@
+const form = document.getElementById('generate-form');
+const logsList = document.getElementById('logs');
+const progressSection = document.getElementById('progress');
+const resultSection = document.getElementById('result');
+const svgContainer = document.getElementById('svg-container');
+const downloadJson = document.getElementById('download-json');
+const downloadSvg = document.getElementById('download-svg');
+
+function addLog(message) {
+  const li = document.createElement('li');
+  li.textContent = message;
+  logsList.appendChild(li);
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  logsList.innerHTML = '';
+  progressSection.style.display = 'block';
+  resultSection.style.display = 'none';
+
+  const width = parseFloat(document.getElementById('width').value);
+  const depth = parseFloat(document.getElementById('depth').value);
+  const bedrooms = parseInt(document.getElementById('bedrooms').value, 10);
+  const fullBath = parseInt(document.getElementById('bath_full').value, 10);
+  const halfBath = parseInt(document.getElementById('bath_half').value, 10);
+  const adjacencyText = document.getElementById('adjacency').value.trim();
+
+  let roomAdjacency;
+  if (adjacencyText) {
+    try {
+      roomAdjacency = JSON.parse(adjacencyText);
+    } catch (err) {
+      alert('Invalid JSON for room adjacency');
+      return;
+    }
+  }
+
+  const params = {
+    dimensions: { width, depth },
+    bedrooms,
+    bathrooms: { full: fullBath, half: halfBath },
+  };
+  if (roomAdjacency) {
+    params.roomAdjacency = roomAdjacency;
+  }
+
+  addLog('Submitting job...');
+
+  const response = await fetch('/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ params })
+  });
+  const data = await response.json();
+  const jobId = data.job_id;
+  addLog('Job queued with ID ' + jobId);
+
+  const protocol = (location.protocol === 'https:') ? 'wss' : 'ws';
+  const ws = new WebSocket(`${protocol}://${location.host}/ws/${jobId}`);
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+    if (msg.log) {
+      addLog(msg.log);
+    } else if (msg.status === 'completed') {
+      ws.close();
+      addLog('Completed in ' + msg.result.metadata.processing_time.toFixed(2) + 's');
+
+      svgContainer.innerHTML = `<img src="${msg.result.svg_data_url}" alt="Blueprint" />`;
+
+      const jsonBlob = new Blob([JSON.stringify(msg.result.layout, null, 2)], { type: 'application/json' });
+      const jsonUrl = URL.createObjectURL(jsonBlob);
+      downloadJson.href = jsonUrl;
+      downloadJson.download = msg.result.json_filename || 'layout.json';
+
+      const svgData = atob(msg.result.svg_data_url.split(',')[1]);
+      const svgBlob = new Blob([svgData], { type: 'image/svg+xml' });
+      const svgUrl = URL.createObjectURL(svgBlob);
+      downloadSvg.href = svgUrl;
+      downloadSvg.download = msg.result.svg_filename || 'layout.svg';
+
+      resultSection.style.display = 'block';
+    } else if (msg.status === 'failed') {
+      ws.close();
+      addLog('Error: ' + msg.error);
+    }
+  };
+});

--- a/interface/web/index.html
+++ b/interface/web/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>House Blueprint Generator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    fieldset { margin-bottom: 1rem; }
+    #svg-container img { max-width: 100%; border: 1px solid #ccc; }
+    #logs { list-style-type: none; padding-left: 0; }
+    #logs li { margin-bottom: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>House Blueprint Generator</h1>
+  <form id="generate-form">
+    <fieldset>
+      <legend>Dimensions</legend>
+      <label>Width: <input type="number" step="0.1" id="width" required></label>
+      <label>Depth: <input type="number" step="0.1" id="depth" required></label>
+    </fieldset>
+    <fieldset>
+      <legend>Rooms</legend>
+      <label>Bedrooms: <input type="number" id="bedrooms" value="3"></label>
+      <label>Full Bathrooms: <input type="number" id="bath_full" value="2"></label>
+      <label>Half Bathrooms: <input type="number" id="bath_half" value="0"></label>
+    </fieldset>
+    <fieldset>
+      <legend>Room Adjacency (JSON)</legend>
+      <textarea id="adjacency" rows="4" placeholder='{"kitchen": ["living_room"]}'></textarea>
+    </fieldset>
+    <button type="submit">Generate</button>
+  </form>
+
+  <section id="progress" style="display:none;">
+    <h2>Progress</h2>
+    <ul id="logs"></ul>
+  </section>
+
+  <section id="result" style="display:none;">
+    <h2>Generated Layout</h2>
+    <div id="svg-container"></div>
+    <p>
+      <a id="download-json" href="#" download="layout.json">Download JSON</a>
+      |
+      <a id="download-svg" href="#" download="layout.svg">Download SVG</a>
+    </p>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose `interface/web` as a static site so the SPA can reach the API
- add viewport meta tag to frontend index to resolve merge conflict and improve mobile rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a61c1a0ee0832c8bcd232e81da2ecb