### PR TITLE
Add API key auth, per-user rate limiting, and request logging

### DIFF
--- a/interface/web/src/pages/Design.tsx
+++ b/interface/web/src/pages/Design.tsx
@@ -69,6 +69,9 @@ const DesignPage = () => {
   // Holds message for modal display when requests fail
   const [errorMessage, setErrorMessage] = useState('');
 
+  // Store API key for authenticated requests
+  const [apiKey, setApiKey] = useState<string | null>(null);
+
   /**
    * Generate a blueprint by calling the backend API and polling for completion.
    *
@@ -89,9 +92,15 @@ const DesignPage = () => {
       }
     };
 
+    let key = apiKey;
+    if (!key) {
+      key = window.prompt('Enter API key') || '';
+      if (!key) throw new Error('API key required');
+      setApiKey(key);
+    }
     const resp = await fetch(`${API_BASE_URL}/generate`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': key },
       body: JSON.stringify(payload)
     });
 
@@ -103,7 +112,9 @@ const DesignPage = () => {
 
     // Poll job status until completion
     while (true) {
-      const statusResp = await fetch(`${API_BASE_URL}/status/${job_id}`);
+      const statusResp = await fetch(`${API_BASE_URL}/status/${job_id}`, {
+        headers: { 'X-API-Key': key }
+      });
       if (!statusResp.ok) {
         throw new Error('Failed to get job status');
       }


### PR DESCRIPTION
## Summary
- Secure API with header-based API keys and enforce per-user rate limits
- Log request/response bodies and expose Prometheus metrics
- Frontend prompts for API key and sends it with blueprint generation requests

## Testing
- `pytest`

