### PR TITLE
Add Docker deployment and compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+interface/web/node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
+# Build front-end assets
+FROM node:20 AS frontend
+WORKDIR /app/interface/web
+COPY interface/web/package*.json ./
+RUN npm ci
+COPY interface/web .
+# Build with API base URL baked in
+ARG VITE_API_BASE_URL=http://localhost:8000
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+RUN npm run build
+
+# Final image with API and model
 FROM python:3.11-slim
-
 WORKDIR /app
-
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code and model weights
 COPY . .
+# Copy built front-end assets from builder stage
+COPY --from=frontend /app/interface/web/dist interface/web/dist
 
 # Ensure model weights exist to avoid runtime surprises
 RUN test -f checkpoints/model_latest.pth || echo 'Warning: model weights not found'

--- a/README.md
+++ b/README.md
@@ -72,3 +72,49 @@ python interface/cli.py --params sample_params.json
 ```
 
 The `--seed` flag on `build_jsonl.py` ensures the shuffled train/val split is reproducible.
+
+## Deployment
+
+### Build the Container
+
+The provided `Dockerfile` bundles the API server, model weights (if present in
+`checkpoints/`), and the front-end assets. Build the image locally:
+
+```bash
+docker build -t blueprint-generator .
+```
+
+You can override the API URL baked into the front-end with the
+`VITE_API_BASE_URL` build argument:
+
+```bash
+docker build -t blueprint-generator \
+  --build-arg VITE_API_BASE_URL=https://example.com \
+  .
+```
+
+### docker-compose
+
+Use the included `docker-compose.yml` to run the web server, optional Redis
+queue, and Prometheus monitoring:
+
+```bash
+docker-compose up --build
+```
+
+Services:
+
+* **app** – FastAPI server serving the API and static front-end at
+  `http://localhost:8000/app/`
+* **queue** – Redis instance for background jobs (optional)
+* **prometheus** – metrics collector available at `http://localhost:9090`
+
+### Environment Variables
+
+* `DEVICE` – set to `cpu` or `cuda` to control inference hardware (default:
+  `cpu`).
+* `RATE_LIMIT` – requests per API key per minute (default: `60`).
+
+For production deployments, build the image with the desired API base URL and
+run using docker-compose with the appropriate environment variables set (e.g.
+`DEVICE=cuda`).

--- a/api/app.py
+++ b/api/app.py
@@ -11,6 +11,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from fastapi.exceptions import RequestValidationError
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from prometheus_client import (
     Counter,
@@ -451,3 +452,8 @@ async def job_updates(websocket: WebSocket, job_id: str):
         logger.info("WebSocket disconnected for job %s", job_id)
     finally:
         await websocket.close()
+
+# Serve built front-end assets if present
+frontend_dir = os.path.join(REPO_ROOT, "interface", "web", "dist")
+if os.path.isdir(frontend_dir):
+    app.mount("/app", StaticFiles(directory=frontend_dir, html=True), name="frontend")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,14 @@ services:
       - "8000:8000"
     environment:
       - DEVICE=cpu
+      - RATE_LIMIT=60
+    depends_on:
+      - queue
+  queue:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -14,3 +22,5 @@ services:
       - "9090:9090"
     depends_on:
       - app
+volumes:
+  redis-data:


### PR DESCRIPTION
## Summary
- build frontend assets and API into a single Docker image
- serve built UI from the API at `/app`
- docker-compose with optional Redis queue and Prometheus

## Testing
- `pytest`


