### PR TITLE
Add structured params validation and user term mapping

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -31,7 +31,7 @@ def main():
 
     try:
         raw = json.load(open(args.params_json, "r", encoding="utf-8"))
-        params = Params(**raw)
+        params = Params.model_validate(raw)
     except (json.JSONDecodeError, ValidationError) as e:
         print(f"Invalid parameters: {e}", file=sys.stderr)
         sys.exit(1)

--- a/tokenizer/tokenizer.py
+++ b/tokenizer/tokenizer.py
@@ -26,7 +26,9 @@ class BlueprintTokenizer:
         # Map common user-facing terms to internal tokens
         self.term_to_token = {
             "master bedroom": "OWNER_SUITE_MAIN",
+            "master suite": "OWNER_SUITE_MAIN",
             "primary bedroom": "OWNER_SUITE_MAIN",
+            "primary suite": "OWNER_SUITE_MAIN",
             "owner's suite": "OWNER_SUITE_MAIN",
             "master bath": "BATHROOM",
             "half bath": "BATHROOM",
@@ -81,13 +83,24 @@ class BlueprintTokenizer:
         if params.get("vaultedCeilings"): ids.append(self.token_to_id["VAULTED"])
 
         loc = (params.get("ownerSuiteLocation") or "").lower()
-        if "main" in loc: ids.append(self.token_to_id["OWNER_SUITE_MAIN"])
-        elif "upper" in loc: ids.append(self.token_to_id["OWNER_SUITE_UPPER"])
+        mapped = self.term_to_token.get(loc)
+        if mapped:
+            ids.append(self.token_to_id[mapped])
+        elif "main" in loc:
+            ids.append(self.token_to_id["OWNER_SUITE_MAIN"])
+        elif "upper" in loc:
+            ids.append(self.token_to_id["OWNER_SUITE_UPPER"])
 
         bath = (params.get("masterBathOption") or "").lower()
-        if "both" in bath: ids.append(self.token_to_id["BATH_BOTH"])
-        elif "tub" in bath: ids.append(self.token_to_id["BATH_TUB"])
-        elif "shower" in bath: ids.append(self.token_to_id["BATH_SHOWER"])
+        mapped = self.term_to_token.get(bath)
+        if mapped:
+            ids.append(self.token_to_id[mapped])
+        elif "both" in bath:
+            ids.append(self.token_to_id["BATH_BOTH"])
+        elif "tub" in bath:
+            ids.append(self.token_to_id["BATH_TUB"])
+        elif "shower" in bath:
+            ids.append(self.token_to_id["BATH_SHOWER"])
 
         if params.get("ceilingHeight"): ids.append(self.token_to_id["CEILING_H"])
         if params.get("windowHeight"): ids.append(self.token_to_id["WINDOW_H"])


### PR DESCRIPTION
## Summary
- add Adjacency and Constraints models with validation to Params
- validate Params via Pydantic in CLI and API before running jobs
- map user-friendly phrases (e.g., master bedroom) to tokenizer tokens

## Testing
- `pytest -q`


