### PR TITLE
Expose decoding strategy and room spacing parameters

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -27,6 +27,12 @@ def main():
     )
     ap.add_argument("--temperature", type=float, default=1.0)
     ap.add_argument("--beam_size", type=int, default=5)
+    ap.add_argument(
+        "--min_separation",
+        type=float,
+        default=1.0,
+        help="Minimum room separation; 0 disables post-processing",
+    )
     args = ap.parse_args()
 
     try:
@@ -53,7 +59,8 @@ def main():
         beam_size=args.beam_size,
     )
     layout_json = tk.decode_layout_tokens(layout_tokens)
-    layout_json = enforce_min_separation(layout_json)
+    if args.min_separation > 0:
+        layout_json = enforce_min_separation(layout_json, args.min_separation)
 
     json_path = f"{args.out_prefix}.json"
     svg_path = f"{args.out_prefix}.svg"

--- a/interface/cli.py
+++ b/interface/cli.py
@@ -20,13 +20,38 @@ def main():
     parser.add_argument(
         "--outdir", default="generated_cli", help="Directory to save outputs"
     )
+    parser.add_argument(
+        "--strategy",
+        default="greedy",
+        choices=["greedy", "sample", "beam"],
+        help="Decoding strategy",
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=1.0, help="Sampling temperature"
+    )
+    parser.add_argument(
+        "--beam_size", type=int, default=5, help="Beam size for beam search"
+    )
+    parser.add_argument(
+        "--min_separation",
+        type=float,
+        default=1.0,
+        help="Minimum room separation; 0 disables",
+    )
     args = parser.parse_args()
 
     with open(args.params, "r", encoding="utf-8") as f:
         params = json.load(f)
 
+    payload = {
+        "params": params,
+        "strategy": args.strategy,
+        "temperature": args.temperature,
+        "beam_size": args.beam_size,
+        "min_separation": args.min_separation,
+    }
     try:
-        resp = requests.post(args.api, json=params)
+        resp = requests.post(args.api, json=payload)
         data = resp.json()
     except Exception as e:
         print(f"Failed to contact API: {e}")

--- a/models/decoding.py
+++ b/models/decoding.py
@@ -1,3 +1,11 @@
+"""Decoding utilities for blueprint token sequences.
+
+This module centralises different strategies used during autoregressive
+generation.  In addition to simple greedy decoding, it supports
+temperature-based sampling and beam search.  The helper :func:`decode`
+provides a unified entry point selecting between the strategies.
+"""
+
 import torch
 from tokenizer.tokenizer import SEP_ID, EOS_ID
 
@@ -60,7 +68,13 @@ def beam_search_decode(
     max_len: int = 160,
     beam_size: int = 5,
 ):
-    """Generate tokens using beam search."""
+    """Generate tokens using beam search.
+
+    Args:
+        beam_size: Number of beams to keep during search. Must be >= 1.
+    """
+    if beam_size < 1:
+        raise ValueError("beam_size must be at least 1")
     model.eval()
     sequences = [(list(prefix_ids), 0.0)]  # (seq, score)
     device = next(model.parameters()).device
@@ -90,7 +104,13 @@ def decode(
     temperature: float = 1.0,
     beam_size: int = 5,
 ):
-    """Unified decoding interface."""
+    """Unified decoding interface.
+
+    Args:
+        strategy: One of ``"greedy"``, ``"sample"`` or ``"beam"``.
+        temperature: Temperature for sampling when ``strategy=='sample'``.
+        beam_size: Beam width used when ``strategy=='beam'``.
+    """
     if strategy == "greedy":
         return greedy_decode(model, prefix_ids, max_len)
     if strategy == "sample":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ def test_generate_returns_job_and_result(tmp_path):
          patch("api.app.decode", lambda *args, **kwargs: []), \
          patch.object(_tokenizer, "encode_params", return_value=[]), \
          patch.object(_tokenizer, "decode_layout_tokens", return_value={}), \
-         patch("api.app.enforce_min_separation", lambda x: x), \
+         patch("api.app.enforce_min_separation", lambda x, min_sep: x), \
          patch("api.app.render_layout_svg", dummy_render), \
          patch("api.app.REPO_ROOT", str(tmp_path)), \
          patch("api.app.uuid.uuid4") as mock_uuid:


### PR DESCRIPTION
## Summary
- document and validate greedy, sampling, and beam decoding strategies
- allow CLI/API callers to choose decoding strategy, temperature and beam size
- support optional minimum room separation in generation

## Testing
- `pytest -q`

