### PR TITLE
Enforce requested room counts during generation

### DIFF
--- a/evaluation/evaluate_sample.py
+++ b/evaluation/evaluate_sample.py
@@ -66,6 +66,12 @@ def compare_with_params(layout: dict, params: dict) -> list[str]:
     return issues
 
 
+def assert_room_counts(layout: dict, params: dict) -> None:
+    """Raise ``ValueError`` if requested room counts are not met."""
+    issues = compare_with_params(layout, params)
+    if issues:
+        raise ValueError("; ".join(issues))
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--params", required=True, help="Path to parameters JSON")

--- a/models/decoding.py
+++ b/models/decoding.py
@@ -10,6 +10,27 @@ import torch
 from tokenizer.tokenizer import SEP_ID, EOS_ID
 
 
+def _apply_room_bias(logits, counts, required_counts, bias=5.0):
+    """Apply biases or constraints for room token counts.
+
+    ``counts`` tracks how many times a room token has been generated so far.
+    ``required_counts`` maps token ids to the desired total count. Once the
+    desired count for a token is met, its logit is set to ``-inf`` to prevent
+    further occurrences. Tokens still required receive a positive ``bias`` to
+    encourage their selection.
+    """
+
+    if not required_counts:
+        return logits
+    for tid, req in required_counts.items():
+        seen = counts.get(tid, 0)
+        if seen >= req:
+            logits[..., tid] = -float("inf")
+        else:
+            logits[..., tid] += bias
+    return logits
+
+
 def _trim_sequence(seq):
     """Return portion after SEP_ID if present."""
     if SEP_ID in seq:
@@ -18,17 +39,21 @@ def _trim_sequence(seq):
     return seq
 
 
-def greedy_decode(model, prefix_ids, max_len: int = 160):
+def greedy_decode(model, prefix_ids, max_len: int = 160, required_counts=None):
     """Generate tokens using greedy argmax decoding."""
     model.eval()
     seq = list(prefix_ids)
     device = next(model.parameters()).device
+    counts = {tid: 0 for tid in (required_counts or {})}
     with torch.no_grad():
         for _ in range(max_len):
             x = torch.tensor([seq], dtype=torch.long, device=device)
             logits = model(x)[:, -1, :]
+            logits = _apply_room_bias(logits, counts, required_counts)
             nxt = int(logits.argmax(dim=-1))
             seq.append(nxt)
+            if nxt in counts:
+                counts[nxt] += 1
             if nxt == EOS_ID:
                 break
     return _trim_sequence(seq)
@@ -39,6 +64,7 @@ def sample_decode(
     prefix_ids,
     max_len: int = 160,
     temperature: float = 1.0,
+    required_counts=None,
 ):
     """Generate tokens using temperature sampling.
 
@@ -50,13 +76,17 @@ def sample_decode(
     model.eval()
     seq = list(prefix_ids)
     device = next(model.parameters()).device
+    counts = {tid: 0 for tid in (required_counts or {})}
     with torch.no_grad():
         for _ in range(max_len):
             x = torch.tensor([seq], dtype=torch.long, device=device)
             logits = model(x)[:, -1, :] / temperature
+            logits = _apply_room_bias(logits, counts, required_counts)
             probs = torch.softmax(logits, dim=-1)
             nxt = int(torch.multinomial(probs, num_samples=1))
             seq.append(nxt)
+            if nxt in counts:
+                counts[nxt] += 1
             if nxt == EOS_ID:
                 break
     return _trim_sequence(seq)
@@ -67,6 +97,7 @@ def beam_search_decode(
     prefix_ids,
     max_len: int = 160,
     beam_size: int = 5,
+    required_counts=None,
 ):
     """Generate tokens using beam search.
 
@@ -76,21 +107,26 @@ def beam_search_decode(
     if beam_size < 1:
         raise ValueError("beam_size must be at least 1")
     model.eval()
-    sequences = [(list(prefix_ids), 0.0)]  # (seq, score)
+    sequences = [(list(prefix_ids), 0.0, {tid: 0 for tid in (required_counts or {})})]  # (seq, score, counts)
     device = next(model.parameters()).device
     with torch.no_grad():
         for _ in range(max_len):
             all_candidates = []
-            for seq, score in sequences:
+            for seq, score, cnts in sequences:
                 x = torch.tensor([seq], dtype=torch.long, device=device)
                 logits = model(x)[:, -1, :]
+                logits = _apply_room_bias(logits, cnts, required_counts)
                 log_probs = torch.log_softmax(logits, dim=-1)
                 topk_log_probs, topk_ids = torch.topk(log_probs, beam_size)
                 for log_prob, idx in zip(topk_log_probs[0], topk_ids[0]):
-                    candidate = (seq + [int(idx)], score + float(log_prob))
+                    new_cnts = dict(cnts)
+                    tid = int(idx)
+                    if tid in new_cnts:
+                        new_cnts[tid] += 1
+                    candidate = (seq + [tid], score + float(log_prob), new_cnts)
                     all_candidates.append(candidate)
             sequences = sorted(all_candidates, key=lambda t: t[1], reverse=True)[:beam_size]
-            if any(seq[-1] == EOS_ID for seq, _ in sequences):
+            if any(seq[-1] == EOS_ID for seq, _, _ in sequences):
                 break
     best_seq = sequences[0][0]
     return _trim_sequence(best_seq)
@@ -103,6 +139,7 @@ def decode(
     strategy: str = "greedy",
     temperature: float = 1.0,
     beam_size: int = 5,
+    required_counts=None,
 ):
     """Unified decoding interface.
 
@@ -112,9 +149,9 @@ def decode(
         beam_size: Beam width used when ``strategy=='beam'``.
     """
     if strategy == "greedy":
-        return greedy_decode(model, prefix_ids, max_len)
+        return greedy_decode(model, prefix_ids, max_len, required_counts)
     if strategy == "sample":
-        return sample_decode(model, prefix_ids, max_len, temperature)
+        return sample_decode(model, prefix_ids, max_len, temperature, required_counts)
     if strategy == "beam":
-        return beam_search_decode(model, prefix_ids, max_len, beam_size)
+        return beam_search_decode(model, prefix_ids, max_len, beam_size, required_counts)
     raise ValueError(f"Unknown decoding strategy: {strategy}")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -46,6 +46,7 @@ def test_generate_blueprint_device_flag(dummy_checkpoint, monkeypatch, tmp_path)
     # patch model and rendering
     monkeypatch.setattr(gb, "LayoutTransformer", DummyModel)
     monkeypatch.setattr(gb, "render_layout_svg", dummy_render)
+    monkeypatch.setattr(gb, "assert_room_counts", lambda layout, params: None)
 
     out_prefix = tmp_path / "output"
     argv = [


### PR DESCRIPTION
## Summary
- Allow decoding to limit room tokens via required counts and biasing
- Pass requested room counts through CLI and API and validate post-generation
- Add helper to assert room counts and update tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac810f842c832cb6ef5cb64f829ad6