### PR TITLE
Clamp layout generation within 40x40 bounds

### DIFF
--- a/dataset/augmentation.py
+++ b/dataset/augmentation.py
@@ -1,6 +1,16 @@
 import copy
 from typing import Dict
 
+MAX_COORD = 40
+
+
+def _clamp_rooms(rooms, max_coord: int = MAX_COORD) -> None:
+    for r in rooms:
+        w = r["size"]["width"]
+        l = r["size"]["length"]
+        r["position"]["x"] = max(0, min(r["position"]["x"], max_coord - w))
+        r["position"]["y"] = max(0, min(r["position"]["y"], max_coord - l))
+
 
 def mirror_layout(layout: Dict) -> Dict:
     """Mirror layout horizontally across its bounding box."""
@@ -12,6 +22,7 @@ def mirror_layout(layout: Dict) -> Dict:
     min_x, max_x = min(xs), max(xs)
     for r in rooms:
         r["position"]["x"] = max_x - (r["position"]["x"] - min_x)
+    _clamp_rooms(rooms)
     return out
 
 
@@ -32,6 +43,7 @@ def rotate_layout(layout: Dict) -> Dict:
         r["position"]["y"] = width - (x - min_x) + min_y
         w, l = r["size"]["width"], r["size"]["length"]
         r["size"]["width"], r["size"]["length"] = l, w
+    _clamp_rooms(rooms)
     return out
 
 

--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -40,13 +40,14 @@ def sample_parameters(i, rng=random):
 
 def random_layout(i, rng=random):
     """Generate a random layout with explicit x/y coordinates."""
-    base_x = rng.randint(0, 20)
-    base_y = rng.randint(0, 20)
+    # Restrict base/offset ranges so raw coordinates stay below MAX_COORD
+    base_x = rng.randint(0, 19)
+    base_y = rng.randint(0, 19)
     rooms = []
     for _ in range(rng.randint(3, 6)):
         room_type = rng.choice(ROOM_TYPES)
-        x = base_x + rng.randint(0, 20)
-        y = base_y + rng.randint(0, 20)
+        x = base_x + rng.randint(0, 19)
+        y = base_y + rng.randint(0, 19)
         width = rng.randint(8, 16)
         length = rng.randint(8, 16)
         rooms.append(


### PR DESCRIPTION
## Summary
- Keep initial room coordinates under 40 by limiting base and offset ranges
- Clamp mirrored and rotated layouts so rooms stay inside the 40×40 grid

## Testing
- `python dataset/generate_dataset.py --n 10 --seed 42 --augment`
- `python -m scripts.build_jsonl --seed 42 --augment`
- `pytest`

