### PR TITLE
Constrain room coordinates to canvas

### DIFF
--- a/dataset/augmentation.py
+++ b/dataset/augmentation.py
@@ -5,11 +5,17 @@ MAX_COORD = 40
 
 
 def _clamp_rooms(rooms, max_coord: int = MAX_COORD) -> None:
+    """Clamp rooms to the canvas; drop any that cannot fit."""
+    clamped = []
     for r in rooms:
         w = r["size"]["width"]
         l = r["size"]["length"]
+        if w > max_coord or l > max_coord:
+            continue
         r["position"]["x"] = max(0, min(r["position"]["x"], max_coord - w))
         r["position"]["y"] = max(0, min(r["position"]["y"], max_coord - l))
+        clamped.append(r)
+    rooms[:] = clamped
 
 
 def mirror_layout(layout: Dict) -> Dict:

--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -40,16 +40,17 @@ def sample_parameters(i, rng=random):
 
 def random_layout(i, rng=random):
     """Generate a random layout with explicit x/y coordinates."""
-    # Restrict base/offset ranges so raw coordinates stay below MAX_COORD
-    base_x = rng.randint(0, 19)
-    base_y = rng.randint(0, 19)
+    # Choose a base anchor well within the canvas so rooms stay in-bounds.
+    base_x = rng.randint(0, 23)
+    base_y = rng.randint(0, 23)
     rooms = []
     for _ in range(rng.randint(3, 6)):
         room_type = rng.choice(ROOM_TYPES)
-        x = base_x + rng.randint(0, 19)
-        y = base_y + rng.randint(0, 19)
         width = rng.randint(8, 16)
         length = rng.randint(8, 16)
+        # Offsets are limited by remaining space so that x+width<=MAX_COORD
+        x = base_x + rng.randint(0, 16 - width)
+        y = base_y + rng.randint(0, 16 - length)
         rooms.append(
             {
                 "type": room_type,


### PR DESCRIPTION
## Summary
- Ensure random room placement never exceeds 40x40 canvas by constraining base anchors and offsets
- Clamp augmented layouts and drop rooms that cannot fit within the canvas

## Testing
- `pytest -q`
- `python dataset/generate_dataset.py --n 5 --seed 0 --augment`
- `python scripts/build_jsonl.py --augment --seed 0`
- `python - <<'PY'\nimport os, json, glob\nmax_coord = 40\nfor f in glob.glob('dataset/datasets/synthetic/layout_*.json'):\n    data = json.load(open(f))\n    for room in data['layout']['rooms']:\n        x = room['position']['x']; y = room['position']['y']\n        w = room['size']['width']; l = room['size']['length']\n        assert x + w <= max_coord and y + l <= max_coord, f'{f} out of bounds'\nprint('All layouts within bounds')\nPY`


