### PR TITLE
Validate layout coordinates in dataset builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The optional `--seed` flag ensures reproducible shuffling.
 
 All layouts are scaled to fit within a 40×40 coordinate space. Rooms whose
 positions or dimensions would exceed these bounds are scaled down before being
-written. The preprocessing step in `scripts/build_jsonl.py` enforces this limit
-and will raise an error if any room falls outside the `[0, 40]` range.
+written. The preprocessing step in `scripts/build_jsonl.py` verifies that every
+room supplies both `x` and `y` coordinates and enforces the `[0, 40]` range,
+raising an error if a room is missing a coordinate or lies outside the bounds.
 
 ## Training
 


### PR DESCRIPTION
## Summary
- add `_validate_layout` helper that checks room positions include `x` and `y` and fall within `[0, 40]`
- validate original and augmented layouts in `scripts/build_jsonl.py`
- document coordinate validation in README

## Testing
- `pytest -q`


