### PR TITLE
Seed dataset generation for reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Synthetic layouts are produced with parameter files in `dataset/params/` and
 converted into paired JSONL records for training. Run:
 
 ```bash
-python dataset/generate_dataset.py                 # create JSON + SVG pairs
+python dataset/generate_dataset.py --seed 42       # create JSON + SVG pairs
 python scripts/build_jsonl.py --seed 42            # shuffle into train/val splits
 ```
 
-The optional `--seed` flag ensures reproducible shuffling.
+Use the same `--seed` value for both commands to ensure full reproducibility.
 
 All layouts are scaled to fit within a 40×40 coordinate space. Rooms whose
 positions or dimensions would exceed these bounds are scaled down before being

--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -3,6 +3,19 @@ import json
 import sys
 import random
 
+try:
+    import numpy as np
+except Exception:  # NumPy not available
+    np = None
+
+if np is not None:
+    try:
+        import torch  # type: ignore
+    except Exception:  # PyTorch not available
+        torch = None
+else:
+    torch = None
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from dataset.render_svg import render_layout_svg
@@ -149,6 +162,11 @@ def _write_sample(params, layout, out_dir, idx):
 
 
 def main(n=50, out_dir=OUT_DIR, external_dir=None, seed=None, augment=False):
+    random.seed(seed)
+    if np is not None:
+        np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
     os.makedirs(out_dir, exist_ok=True)
     rng = random.Random(seed)
     idx = 0

--- a/scripts/build_jsonl.py
+++ b/scripts/build_jsonl.py
@@ -98,7 +98,10 @@ if __name__ == "__main__":
         "--seed",
         type=int,
         default=42,
-        help="Random seed for shuffling and any libraries in use.",
+        help=(
+            "Random seed for shuffling and any libraries in use. "
+            "Should match the dataset generation seed for full reproducibility."
+        ),
     )
     parser.add_argument(
         "--augment",


### PR DESCRIPTION
## Summary
- Ensure deterministic dataset creation by seeding Python, NumPy, and PyTorch in `generate_dataset.py`
- Clarify that dataset generation and JSONL building must use the same `--seed`
- Expand `build_jsonl.py` help text to emphasize matching seeds

## Testing
- `pytest`

