### PR TITLE
Enforce layout bounds during data prep

### DIFF
--- a/dataset/generate_dataset.py
+++ b/dataset/generate_dataset.py
@@ -182,7 +182,10 @@ def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0, augmen
             "params", {"houseStyle": "External", "squareFeet": data.get("squareFeet", 0)}
         )
 
-        _write_sample(params, layout, out_dir, idx)
+        try:
+            _write_sample(params, layout, out_dir, idx)
+        except ValueError:
+            continue
         idx += 1
         if augment:
             for aug_layout in (mirror_layout(layout), rotate_layout(layout)):
@@ -200,6 +203,7 @@ def ingest_external_dataset(external_dir, out_dir=OUT_DIR, start_index=0, augmen
 
 def _write_sample(params, layout, out_dir, idx):
     layout = _scale_layout(layout)
+    layout = clamp_bounds(layout, max_width=MAX_COORD, max_length=MAX_COORD)
     validate_layout(layout)
     ip = os.path.join(out_dir, f"input_{idx:05d}.json")
     lp = os.path.join(out_dir, f"layout_{idx:05d}.json")
@@ -226,7 +230,10 @@ def main(n=50, out_dir=OUT_DIR, external_dir=None, seed=None, augment=False):
             layout = random_layout(idx, params, rng)
         except ValueError:
             continue
-        _write_sample(params, layout, out_dir, idx)
+        try:
+            _write_sample(params, layout, out_dir, idx)
+        except ValueError:
+            continue
         idx += 1
         if augment:
             for aug_layout in (mirror_layout(layout), rotate_layout(layout)):

--- a/scripts/build_jsonl.py
+++ b/scripts/build_jsonl.py
@@ -41,10 +41,18 @@ def _validate_layout(
         if not pos or "x" not in pos or "y" not in pos:
             raise ValueError(f"Room {idx} missing x or y position")
         x, y = pos["x"], pos["y"]
-        if enforce_bounds and not (0 <= x <= max_coord and 0 <= y <= max_coord):
-            raise ValueError(
-                f"Room {idx} position out of range: x={x}, y={y}, max={max_coord}"
-            )
+        size = room.get("size", {})
+        w = size.get("width", 0)
+        l = size.get("length", 0)
+        if enforce_bounds:
+            if not (0 <= x <= max_coord and 0 <= y <= max_coord):
+                raise ValueError(
+                    f"Room {idx} position out of range: x={x}, y={y}, max={max_coord}"
+                )
+            if x + w > max_coord or y + l > max_coord:
+                raise ValueError(
+                    f"Room {idx} exceeds bounds: x={x}, width={w}, y={y}, length={l}, max={max_coord}"
+                )
 
 def main(seed: int = 42, augment: bool = False, check_bounds: bool = True) -> None:
     random.seed(seed)


### PR DESCRIPTION
## Summary
- Clamp rooms to the 40×40 canvas when writing dataset samples and skip invalid layouts.
- Validate room dimensions during JSONL preprocessing to catch out-of-bounds coordinates.

## Testing
- `pytest -q`
- `python -m dataset.generate_dataset --n 20 --seed 0`
- `python -m scripts.build_jsonl --seed 0`
- `python -m training.train --epochs 1 --batch 4 --device cpu`


