### PR TITLE
Ensure contiguous room layouts

### DIFF
--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,0 +1,14 @@
+import json
+from evaluation.validators import check_connectivity, validate_layout
+
+
+def test_detects_disconnected_rooms():
+    rooms = [
+        {"type": "Bedroom", "position": {"x": 0, "y": 0}, "size": {"width": 5, "length": 5}},
+        {"type": "Kitchen", "position": {"x": 10, "y": 0}, "size": {"width": 5, "length": 5}},
+    ]
+    issues = check_connectivity(rooms)
+    assert issues
+    layout = {"layout": {"rooms": rooms}}
+    issues2 = validate_layout(layout)
+    assert any("not connected" in msg for msg in issues2)


### PR DESCRIPTION
## Summary
- arrange synthetic rooms edge-to-edge instead of scattering randomly
- add connectivity validator ensuring each room shares a wall with another
- include regression test for disconnected rooms

## Testing
- `pytest -q`
- `python -m dataset.generate_dataset --n 20 --seed 0 --out_dir dataset/datasets/synthetic`
- `python -m scripts.build_jsonl`
- `python training/train.py --epochs 1 --batch 4 --device cpu`


