### PR TITLE
Enforce core room requirements in blueprint generation and evaluation

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -72,6 +72,11 @@ def main():
         room_counts[tk.token_to_id["BEDROOM"]] = params.bedrooms
     if "bathrooms" in raw:
         room_counts[tk.token_to_id["BATHROOM"]] = params.bathrooms.full + params.bathrooms.half
+    # Core rooms are always required at least once
+    room_counts[tk.token_to_id["KITCHEN"]] = params.kitchen
+    room_counts[tk.token_to_id["LIVING"]] = params.livingRooms
+    room_counts[tk.token_to_id["DINING"]] = params.diningRooms
+    room_counts[tk.token_to_id["LAUNDRY"]] = params.laundryRooms
     if raw.get("garage"):
         room_counts[tk.token_to_id["GARAGE"]] = 1
         bias_tokens[tk.token_to_id["GARAGE"]] = 2.0

--- a/Generate/params.py
+++ b/Generate/params.py
@@ -49,6 +49,10 @@ class Params(BaseModel):
     stories: Optional[int] = Field(default=1, ge=1)
     bedrooms: int = Field(default=3, ge=0)
     bathrooms: Bathrooms = Bathrooms()
+    kitchen: int = Field(default=1, ge=1)
+    livingRooms: int = Field(default=1, ge=1)
+    diningRooms: int = Field(default=1, ge=1)
+    laundryRooms: int = Field(default=1, ge=1)
     bonusRoom: Optional[bool] = False
     garage: Optional[Garage] = None
     fireplace: Optional[bool] = False

--- a/evaluation/evaluate_sample.py
+++ b/evaluation/evaluate_sample.py
@@ -54,6 +54,27 @@ def assert_room_counts(layout: dict, params: dict) -> list[dict]:
     if bath_found < bath_expected:
         missing.append({"room_type": "bathroom", "expected": bath_expected, "found": bath_found})
 
+    # Core rooms required at least once by default
+    kit_expected = int(params.get("kitchen", 1))
+    kit_found = counts.get("kitchen", 0)
+    if kit_found < kit_expected:
+        missing.append({"room_type": "kitchen", "expected": kit_expected, "found": kit_found})
+
+    liv_expected = int(params.get("livingRooms", 1))
+    liv_found = counts.get("living room", 0)
+    if liv_found < liv_expected:
+        missing.append({"room_type": "living room", "expected": liv_expected, "found": liv_found})
+
+    din_expected = int(params.get("diningRooms", 1))
+    din_found = counts.get("dining room", 0)
+    if din_found < din_expected:
+        missing.append({"room_type": "dining room", "expected": din_expected, "found": din_found})
+
+    lau_expected = int(params.get("laundryRooms", 1))
+    lau_found = counts.get("laundry room", 0)
+    if lau_found < lau_expected:
+        missing.append({"room_type": "laundry room", "expected": lau_expected, "found": lau_found})
+
     if params.get("garage"):
         gar_found = counts.get("garage", 0)
         if gar_found < 1:

--- a/tests/test_evaluate_sample.py
+++ b/tests/test_evaluate_sample.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+import pytest
 
 
 def run_eval(params, layout, svg_path, strict=True, report=None):
@@ -37,7 +38,7 @@ def test_strict_exits_on_issue(tmp_path):
 
 
 def test_strict_allows_clean_layout(tmp_path):
-    params = {"dimensions": {"width": 10, "depth": 10}, "bedrooms": 1}
+    params = {"dimensions": {"width": 20, "depth": 20}, "bedrooms": 1}
     layout = {
         "layout": {
             "rooms": [
@@ -45,7 +46,27 @@ def test_strict_allows_clean_layout(tmp_path):
                     "type": "Bedroom",
                     "position": {"x": 0, "y": 0},
                     "size": {"width": 5, "length": 5},
-                }
+                },
+                {
+                    "type": "Kitchen",
+                    "position": {"x": 5, "y": 0},
+                    "size": {"width": 5, "length": 5},
+                },
+                {
+                    "type": "Living Room",
+                    "position": {"x": 10, "y": 0},
+                    "size": {"width": 5, "length": 5},
+                },
+                {
+                    "type": "Dining Room",
+                    "position": {"x": 0, "y": 5},
+                    "size": {"width": 5, "length": 5},
+                },
+                {
+                    "type": "Laundry Room",
+                    "position": {"x": 5, "y": 5},
+                    "size": {"width": 5, "length": 5},
+                },
             ]
         }
     }
@@ -62,3 +83,24 @@ def test_json_report(tmp_path):
     assert result.returncode == 0
     data = json.loads(report.read_text())
     assert data["bounds_issues"] or data["other_issues"]
+
+
+@pytest.mark.parametrize("missing", [
+    "kitchen",
+    "living room",
+    "dining room",
+    "laundry room",
+])
+def test_missing_core_room_fails(tmp_path, missing):
+    params = {"dimensions": {"width": 20, "depth": 20}}
+    base_rooms = {
+        "kitchen": {"type": "Kitchen", "position": {"x": 0, "y": 0}, "size": {"width": 5, "length": 5}},
+        "living room": {"type": "Living Room", "position": {"x": 5, "y": 0}, "size": {"width": 5, "length": 5}},
+        "dining room": {"type": "Dining Room", "position": {"x": 0, "y": 5}, "size": {"width": 5, "length": 5}},
+        "laundry room": {"type": "Laundry Room", "position": {"x": 5, "y": 5}, "size": {"width": 5, "length": 5}},
+    }
+    rooms = [room for name, room in base_rooms.items() if name != missing]
+    layout = {"layout": {"rooms": rooms}}
+
+    result = run_eval(params, layout, tmp_path / f"out_{missing.replace(' ', '_')}.svg", strict=True)
+    assert result.returncode != 0

--- a/tokenizer/tokenizer.py
+++ b/tokenizer/tokenizer.py
@@ -73,9 +73,18 @@ class BlueprintTokenizer:
         elif "colonial" in style: ids.append(self.token_to_id["STYLE_COLONIAL"])
         elif "modern" in style: ids.append(self.token_to_id["STYLE_MODERN"])
 
-        for _ in range(int(params.get("bedrooms", 0))): ids.append(self.token_to_id["BEDROOM"])
-        for _ in range(int((params.get("bathrooms") or {}).get("full", 0))): ids.append(self.token_to_id["BATHROOM"])
-        ids += [self.token_to_id["KITCHEN"], self.token_to_id["LIVING"], self.token_to_id["DINING"], self.token_to_id["LAUNDRY"]]
+        for _ in range(int(params.get("bedrooms", 0))):
+            ids.append(self.token_to_id["BEDROOM"])
+        for _ in range(int((params.get("bathrooms") or {}).get("full", 0))):
+            ids.append(self.token_to_id["BATHROOM"])
+        for _ in range(int(params.get("kitchen", 1))):
+            ids.append(self.token_to_id["KITCHEN"])
+        for _ in range(int(params.get("livingRooms", 1))):
+            ids.append(self.token_to_id["LIVING"])
+        for _ in range(int(params.get("diningRooms", 1))):
+            ids.append(self.token_to_id["DINING"])
+        for _ in range(int(params.get("laundryRooms", 1))):
+            ids.append(self.token_to_id["LAUNDRY"])
 
         if params.get("bonusRoom"): ids.append(self.token_to_id["BONUS"])
         if params.get("attic"): ids.append(self.token_to_id["ATTIC"])


### PR DESCRIPTION
## Summary
- Require minimum counts for kitchen, living, dining, and laundry rooms in parameters and generation
- Validate generated layouts include all core room types
- Add tests ensuring layouts missing any required room fail validation

## Testing
- `pytest`

