### PR TITLE
Render lot boundary and enforce lot dimensions

### DIFF
--- a/Generate/generate_blueprint.py
+++ b/Generate/generate_blueprint.py
@@ -210,7 +210,7 @@ def main():
         log.error("Failed to write layout JSON to %s: %s", json_path, e)
         sys.exit(1)
     try:
-        render_layout_svg(layout_json, svg_path)
+        render_layout_svg(layout_json, svg_path, lot_dims=(max_w, max_h))
     except OSError as e:
         log.error("Failed to write SVG to %s: %s", svg_path, e)
         sys.exit(1)

--- a/dataset/render_svg.py
+++ b/dataset/render_svg.py
@@ -1,12 +1,51 @@
 import svgwrite
 
-def render_layout_svg(layout_data, svg_path, scale=10):
+
+def render_layout_svg(layout_data, svg_path, lot_dims=None, scale=10):
     rooms = layout_data.get("layout", {}).get("rooms", [])
 
-    # Determine canvas bounds based on room coordinates
-    max_x = max((r.get("position", {}).get("x", 0) + r.get("size", {}).get("width", 0)) for r in rooms) * scale if rooms else 0
-    max_y = max((r.get("position", {}).get("y", 0) + r.get("size", {}).get("length", 0)) for r in rooms) * scale if rooms else 0
-    dwg = svgwrite.Drawing(svg_path, profile='tiny', size=(max_x, max_y))
+    if lot_dims:
+        lot_w, lot_h = lot_dims
+        max_x = lot_w * scale
+        max_y = lot_h * scale
+    else:
+        # Determine canvas bounds based on room coordinates
+        max_x = (
+            max(
+                (
+                    r.get("position", {}).get("x", 0)
+                    + r.get("size", {}).get("width", 0)
+                )
+                for r in rooms
+            )
+            * scale
+            if rooms
+            else 0
+        )
+        max_y = (
+            max(
+                (
+                    r.get("position", {}).get("y", 0)
+                    + r.get("size", {}).get("length", 0)
+                )
+                for r in rooms
+            )
+            * scale
+            if rooms
+            else 0
+        )
+    dwg = svgwrite.Drawing(svg_path, profile="tiny", size=(max_x, max_y))
+
+    if lot_dims:
+        dwg.add(
+            dwg.rect(
+                insert=(0, 0),
+                size=(max_x, max_y),
+                fill="none",
+                stroke="black",
+                stroke_width=3,
+            )
+        )
 
     font_main = "Arial"
     font_size_label = 12

--- a/evaluation/evaluate_sample.py
+++ b/evaluation/evaluate_sample.py
@@ -21,7 +21,7 @@ if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
 from dataset.render_svg import render_layout_svg
-from evaluation.validators import validate_layout, check_bounds
+from evaluation.validators import validate_layout, check_bounds, clamp_bounds
 
 
 log = logging.getLogger(__name__)
@@ -151,8 +151,7 @@ def main() -> None:
     max_w = float(dims.get("width", 40))
     max_h = float(dims.get("depth", dims.get("height", 40)))
 
-    render_layout_svg(layout, args.svg_out)
-    log.info("Rendered layout SVG to %s", Path(args.svg_out).resolve())
+    layout = clamp_bounds(layout, max_w, max_h)
 
     bounds_issues = check_bounds(
         (layout.get("layout") or {}).get("rooms", []),
@@ -173,6 +172,9 @@ def main() -> None:
     issues.extend(compare_with_params(layout, params))
 
     all_issues = bounds_issues + issues
+
+    render_layout_svg(layout, args.svg_out, lot_dims=(max_w, max_h))
+    log.info("Rendered layout SVG to %s", Path(args.svg_out).resolve())
 
     if args.json_report:
         summary = {"bounds_issues": bounds_issues, "other_issues": issues}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from api.app import app, _tokenizer
 
 
-def dummy_render(layout_json, svg_path):
+def dummy_render(layout_json, svg_path, lot_dims=None):
     with open(svg_path, "w", encoding="utf-8") as f:
         f.write("<svg></svg>")
 

--- a/tests/test_dataset_generation.py
+++ b/tests/test_dataset_generation.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 
-def dummy_render(layout, path):
+def dummy_render(layout, path, lot_dims=None):
     Path(path).write_text("<svg></svg>")
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -26,7 +26,7 @@ class DummyModel(torch.nn.Module):
         return logits
 
 
-def dummy_render(layout_json, svg_path):
+def dummy_render(layout_json, svg_path, lot_dims=None):
     Path(svg_path).write_text("<svg></svg>")
 
 

--- a/tests/test_render_svg.py
+++ b/tests/test_render_svg.py
@@ -1,0 +1,36 @@
+import xml.etree.ElementTree as ET
+from dataset.render_svg import render_layout_svg
+from evaluation.validators import clamp_bounds
+
+def test_render_includes_lot_boundary_and_clamps(tmp_path):
+    layout = {
+        "layout": {
+            "rooms": [
+                {
+                    "type": "Bedroom",
+                    "position": {"x": 8, "y": 8},
+                    "size": {"width": 5, "length": 5},
+                }
+            ]
+        }
+    }
+    lot_dims = (10, 10)
+    layout = clamp_bounds(layout, lot_dims[0], lot_dims[1])
+    svg_path = tmp_path / "out.svg"
+    render_layout_svg(layout, svg_path, lot_dims=lot_dims)
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    ns = {"svg": "http://www.w3.org/2000/svg"}
+    rects = root.findall("svg:rect", ns)
+    assert len(rects) == 2
+    lot_rect = next(r for r in rects if r.get("fill") in (None, "none"))
+    assert float(lot_rect.get("width")) == lot_dims[0] * 10
+    assert float(lot_rect.get("height")) == lot_dims[1] * 10
+    room_rect = next(r for r in rects if r is not lot_rect)
+    x = float(room_rect.get("x"))
+    y = float(room_rect.get("y"))
+    w = float(room_rect.get("width"))
+    h = float(room_rect.get("height"))
+    assert x >= 0 and y >= 0
+    assert x + w <= lot_dims[0] * 10
+    assert y + h <= lot_dims[1] * 10


### PR DESCRIPTION
## Summary
- Render outer lot boundary in SVG when lot dimensions are provided
- Pass lot dimensions through blueprint generation and evaluation scripts
- Clamp layouts to lot size prior to validation and rendering
- Test lot boundary rendering and clamping behavior

## Testing
- `pytest`


